### PR TITLE
feat: add in support for async paths

### DIFF
--- a/src/main/models/FlowNode.ts
+++ b/src/main/models/FlowNode.ts
@@ -22,7 +22,23 @@ export class FlowNode extends FlowElement {
     private getConnectors(subtype, element) {
 
         if (subtype === 'start') {
-            return [new FlowElementConnector('connector', element.connector, {})];
+            const connectors = [];
+            connectors.push(
+                new FlowElementConnector('connector', element.connector, {})
+            );
+            if (Array.isArray(element.scheduledPaths)) {
+                for (const asyncElement of element?.scheduledPaths) {
+                    if (asyncElement.connector) {
+                        connectors.push(
+                            new FlowElementConnector('connector', asyncElement.connector, {
+                                childName: asyncElement?.name?.[0] ?? 'AsyncAfterCommit',
+                                childOf: 'rules'
+                            })
+                        )
+                    }
+                }
+            }
+            return connectors;
         } else if (subtype === 'decisions') {
             const connectors = [];
             connectors.push(

--- a/tests/UnconnectedElement.test.ts
+++ b/tests/UnconnectedElement.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import 'mocha';
+import { scan } from '../src';
+import { Flow } from '../src/main/models/Flow';
+import { ScanResult } from '../src/main/models/ScanResult';
+import unconnectedElement from './testfiles/UnconnectedElement.json';
+import asyncAfterCommitOnly from './testfiles/AsyncAfterCommitOnly.json';
+import waitForOnly from './testfiles/WaitForOnly.json';
+
+
+describe('In the unconnected element flow', () => {
+  let flow: Flow;
+  
+  it('there should be consideration for async elements', () => {
+    flow = new Flow({
+      path: './testfiles/Async_AfterCommitOnly.flow',
+      xmldata: asyncAfterCommitOnly,
+    });
+    const results: ScanResult[] = scan([flow]);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults.length).to.equal(0);
+  });
+
+  it('there should consideration for async wait paths', () => {
+    flow = new Flow({
+      path: './testfiles/Async_AfterCommitOnly.flow',
+      xmldata: waitForOnly,
+    });
+    const results: ScanResult[] = scan([flow]);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults.length).to.equal(0);
+  });
+
+  it('there should be checks for unconnected element', () => {
+    flow = new Flow({
+      path: './testfiles/Async_AfterCommitOnly.flow',
+      xmldata: unconnectedElement,
+    });
+    const results: ScanResult[] = scan([flow]);
+    const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
+    expect(occurringResults.length).to.equal(1);
+    expect(occurringResults[0].ruleName).to.equal("UnconnectedElement");
+  });
+});
+

--- a/tests/testfiles/AsyncAfterCommitOnly.json
+++ b/tests/testfiles/AsyncAfterCommitOnly.json
@@ -1,0 +1,58 @@
+{
+    "Flow": {
+      "$": { "xmlns": "http://soap.sforce.com/2006/04/metadata" },
+      "apiVersion": ["60.0"],
+      "assignments": [
+        {
+          "description": ["Default Action for Asynchronous Transaction"],
+          "name": ["VariableAssignment"],
+          "label": ["VariableAssignment"],
+          "locationX": ["308"],
+          "locationY": ["276"],
+          "assignmentItems": [
+            {
+              "assignToReference": ["$Record.Name"],
+              "operator": ["Assign"],
+              "value": [{ "stringValue": ["Test"] }]
+            }
+          ]
+        }
+      ],
+      "description": ["AsyncOnlyAutomation"],
+      "environments": ["Default"],
+      "interviewLabel": ["Async_OnlyTransaction {!$Flow.CurrentDateTime}"],
+      "label": ["Async_OnlyTransaction"],
+      "processMetadataValues": [
+        {
+          "name": ["BuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        },
+        {
+          "name": ["CanvasMode"],
+          "value": [{ "stringValue": ["AUTO_LAYOUT_CANVAS"] }]
+        },
+        {
+          "name": ["OriginBuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        }
+      ],
+      "processType": ["AutoLaunchedFlow"],
+      "start": [
+        {
+          "locationX": ["50"],
+          "locationY": ["0"],
+          "object": ["Account"],
+          "recordTriggerType": ["Create"],
+          "scheduledPaths": [
+            {
+              "connector": [{ "targetReference": ["VariableAssignment"] }],
+              "pathType": ["AsyncAfterCommit"]
+            }
+          ],
+          "triggerType": ["RecordAfterSave"]
+        }
+      ],
+      "status": ["Active"]
+    }
+  }
+  

--- a/tests/testfiles/UnconnectedElement.json
+++ b/tests/testfiles/UnconnectedElement.json
@@ -1,0 +1,66 @@
+{
+    "Flow": {
+      "$": { "xmlns": "http://soap.sforce.com/2006/04/metadata" },
+      "apiVersion": ["60.0"],
+      "assignments": [
+        {
+          "name": ["NotAssigned"],
+          "label": ["Not Assigned"],
+          "locationX": ["50"],
+          "locationY": ["276"],
+          "assignmentItems": [
+            {
+              "assignToReference": ["$Record.Name"],
+              "operator": ["Assign"],
+              "value": [{ "stringValue": ["Unassigned"] }]
+            }
+          ]
+        },
+        {
+          "description": ["Default Action for Asynchronous Transaction"],
+          "name": ["VariableAssignment"],
+          "label": ["VariableAssignment"],
+          "locationX": ["314"],
+          "locationY": ["276"],
+          "assignmentItems": [
+            {
+              "assignToReference": ["$Record.Name"],
+              "operator": ["Assign"],
+              "value": [{ "stringValue": ["Test"] }]
+            }
+          ]
+        }
+      ],
+      "description": ["AsyncOnlyAutomation"],
+      "environments": ["Default"],
+      "interviewLabel": ["AsyncOnlyTransaction {!$Flow.CurrentDateTime}"],
+      "label": ["Async_OnlyTransaction"],
+      "processMetadataValues": [
+        {
+          "name": ["BuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        },
+        {
+          "name": ["CanvasMode"],
+          "value": [{ "stringValue": ["AUTO_LAYOUT_CANVAS"] }]
+        },
+        {
+          "name": ["OriginBuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        }
+      ],
+      "processType": ["AutoLaunchedFlow"],
+      "start": [
+        {
+          "locationX": ["56"],
+          "locationY": ["0"],
+          "object": ["Account"],
+          "connector": [{ "targetReference": ["VariableAssignment"] }],
+          "recordTriggerType": ["Create"],
+          "triggerType": ["RecordAfterSave"]
+        }
+      ],
+      "status": ["Active"]
+    }
+  }
+  

--- a/tests/testfiles/WaitForOnly.json
+++ b/tests/testfiles/WaitForOnly.json
@@ -1,0 +1,63 @@
+{
+    "Flow": {
+      "$": { "xmlns": "http://soap.sforce.com/2006/04/metadata" },
+      "apiVersion": ["60.0"],
+      "assignments": [
+        {
+          "description": ["Default Action for Asynchronous Transaction"],
+          "name": ["VariableAssignment"],
+          "label": ["VariableAssignment"],
+          "locationX": ["706"],
+          "locationY": ["382"],
+          "assignmentItems": [
+            {
+              "assignToReference": ["$Record.Name"],
+              "operator": ["Assign"],
+              "value": [{ "stringValue": ["Test"] }]
+            }
+          ]
+        }
+      ],
+      "description": ["AsyncOnlyAutomation"],
+      "environments": ["Default"],
+      "interviewLabel": ["AsyncOnlyTransaction {!$Flow.CurrentDateTime}"],
+      "label": ["Async_OnlyTransaction"],
+      "processMetadataValues": [
+        {
+          "name": ["BuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        },
+        {
+          "name": ["CanvasMode"],
+          "value": [{ "stringValue": ["FREE_FORM_CANVAS"] }]
+        },
+        {
+          "name": ["OriginBuilderType"],
+          "value": [{ "stringValue": ["LightningFlowBuilder"] }]
+        }
+      ],
+      "processType": ["AutoLaunchedFlow"],
+      "start": [
+        {
+          "locationX": ["185"],
+          "locationY": ["0"],
+          "object": ["Account"],
+          "recordTriggerType": ["Create"],
+          "scheduledPaths": [
+            { "pathType": ["AsyncAfterCommit"] },
+            {
+              "name": ["Wait_For"],
+              "connector": [{ "targetReference": ["VariableAssignment"] }],
+              "label": ["Wait For"],
+              "offsetNumber": ["2"],
+              "offsetUnit": ["Hours"],
+              "timeSource": ["RecordTriggerEvent"]
+            }
+          ],
+          "triggerType": ["RecordAfterSave"]
+        }
+      ],
+      "status": ["Active"]
+    }
+  }
+  


### PR DESCRIPTION
# Background

Asynchronous paths aren't being considered when parsing for FlowNodes.
Unlike Synchronous paths where the start element immediately has `connectors`; async paths branch off of `scheduledPaths`

From my investigation there are 2 flavors of scheduledPaths
- scheduled paths that doesn't have a name which are "AsyncAfterCommit"
<img width="770" alt="ScheduledPath1" src="https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/assets/6131635/72e46ebb-9081-4628-9abe-4f49966f350d">

- scheduled paths that do have a name that is based off of a date/time field
<img width="739" alt="ScheduledPath2" src="https://github.com/Lightning-Flow-Scanner/lightning-flow-scanner-core/assets/6131635/6023d71f-3160-4b2f-95d7-41293070173e">

