### PR TITLE
test: swc compiler output for base package

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -2,7 +2,7 @@
   "$schema": "https://swc.rs/schema.json",
   "sourceMaps": "inline",
   "module": {
-    "type": "commonjs",
+    "type": "es6",
     "strictMode": true,
     "noInterop": false
   },

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -2,6 +2,7 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
+  cwd: "out",
   branches: [
     {
       name: "master",


### PR DESCRIPTION
# What's changed?
- Use SWC for compiling and sending over to npm registry