### PR TITLE
fix: add object checks to filter record triggered flows only #206

### DIFF
--- a/src/main/rules/TriggerOrder.ts
+++ b/src/main/rules/TriggerOrder.ts
@@ -28,6 +28,10 @@ export class TriggerOrder extends RuleCommon implements core.IRuleDefinition {
   public execute(flow: core.Flow): core.RuleResult {
     const results: core.ResultDetails[] = [];
 
+    if (!("object" in flow.start)) {
+      return new core.RuleResult(this, results);
+    }
+
     if (!flow.triggerOrder) {
       results.push(
         new core.ResultDetails(

--- a/tests/TriggerOrder.test.ts
+++ b/tests/TriggerOrder.test.ts
@@ -10,6 +10,9 @@ describe("TriggerOrder", () => {
       {
         flow: {
           type: "AutoLaunchedFlow",
+          start: {
+            object: "Account",
+          },
         },
       } as Partial<ParsedFlow> as ParsedFlow,
     ];
@@ -54,6 +57,9 @@ describe("TriggerOrder", () => {
       {
         flow: {
           type: "AutoLaunchedFlow",
+          start: {
+            object: "Account",
+          },
         },
       } as Partial<ParsedFlow> as ParsedFlow,
     ];
@@ -79,6 +85,9 @@ describe("TriggerOrder", () => {
     const testData: ParsedFlow = {
       flow: {
         type: "AutoLaunchedFlow",
+        start: {
+          object: "Account",
+        },
       },
     } as Partial<ParsedFlow> as ParsedFlow;
 
@@ -92,6 +101,9 @@ describe("TriggerOrder", () => {
       flow: {
         triggerOrder: 10,
         type: "AutoLaunchedFlow",
+        start: {
+          object: "Account",
+        },
       },
     } as Partial<ParsedFlow> as ParsedFlow;
 


### PR DESCRIPTION
Fix #206 